### PR TITLE
Fix DataConnectionFeedOptions params

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1517,13 +1517,10 @@ definitions:
   DataConnectionFeedOptions:
     type: object
     properties:
-      params:
-        type: object
-        properties:
-          data_id:
-            description: Dataを特定するためのIDです
-            type: string
-            example: "da-50a32bab-b3d9-4913-8e20-f79c90a6a211"
+      data_id:
+        description: Dataを特定するためのIDです
+        type: string
+        example: "da-50a32bab-b3d9-4913-8e20-f79c90a6a211"
 
  #PUT /data/connections/ID/redirect/ID
   DataConnectionRedirectOptions:


### PR DESCRIPTION
ドキュメントが間違っているようでしたので修正しました

https://github.com/skyway/skyway-webrtc-gateway/blob/2cb86bc8b74e7e781b8b9ffc9ac8c29ac6a22bf3/samples/util.rb#L222

feed_paramsの中にdata_idがある

https://github.com/skyway/skyway-webrtc-gateway/blob/f6698a243776a2767c4b7f1001c96d1d8b16c0fe/api/api.yaml#L1520

paramsの中にdata_idがある