### PR TITLE
Update api reference for peer authentication

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1321,7 +1321,7 @@ definitions:
       ttl:
         description: クレデンシャルの生存期間です。timestampからttl秒経過したとき、クレデンシャルが失効します。
         type: integer
-        minimum: 300
+        minimum: 600
         maximum: 90000
         example: 3600
       authToken:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   description: 'SkyWay WebRTC Gatewayを操作するためのREST API仕様書'
-  version: 1.0.0
+  version: 0.3.0
   title: SkyWay WebRTC Gateway REST API
   termsOfService: 'http://nttcom.github.io/skyway/'
   contact:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -39,7 +39,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: SkyWayサーバへアクセスするための情報を指定します。Peerの認証機能が有効の場合のみクレデンシャルが必要です
+          description: SkyWayサーバへアクセスするための情報を指定します。Peerの認証機能が有効になっている場合は、クレデンシャルが必要です
           required: true
           schema:
             $ref: '#/definitions/PeerOptions'

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -144,7 +144,7 @@ paths:
       tags:
         - 1.peers
       summary: Peer認証のクレデンシャルを更新します
-      description: シグナリングサーバに接続し、Peer認証のクレデンシャルを更新します。Peer認証機能が有効でなければ、クレデンシャルを更新する要求は無視されます。このとき、エラーイベントは発火しません
+      description: SkyWayサーバに接続し、Peer認証のクレデンシャルを更新します。Peer認証機能が有効でなければ、クレデンシャルを更新する要求は無視されます。このとき、エラーイベントは発火しません
       operationId: peer_credential_update
       consumes:
         - application/json

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -144,7 +144,7 @@ paths:
       tags:
         - 1.peers
       summary: Peer認証のクレデンシャルを更新します
-      description: Peer認証のクレデンシャルを更新するためのリクエストをシグナリングサーバに送信します
+      description: Peer認証のクレデンシャルを更新するためのリクエストをシグナリングサーバに送信します。このAPIは認証機能が有効の場合のみ使えます
       operationId: peer_credential_update
       consumes:
         - application/json
@@ -163,7 +163,7 @@ paths:
           required: true
         - in: body
           name: credential
-          description: Peerを認証するためのクレデンシャルです。認証機能が有効の場合のみ使えます
+          description: Peerを認証するためのクレデンシャルです
           required: true
           schema:
             $ref: '#/definitions/PeerCredential'
@@ -176,7 +176,10 @@ paths:
                 type: string
                 example: "PEERS_CREDENTIAL_UPDATE"
               params:
-                $ref: '#/definitions/PeerCredential'
+                type: object
+                properties:
+                  credential:
+                    $ref: '#/definitions/PeerCredential'
 
         '400':
           description: Invalid input
@@ -1557,7 +1560,10 @@ definitions:
       data_params:
         $ref: '#/definitions/DataParametsers'
       remainingSec:
-        $ref: '#/definitions/RemainingSec'
+        description: expiresinイベントのときのみ含まれます。クレデンシャルが失効するまでの時間(秒)です
+        type: integer
+        example: 300
+
       error_message:
         description: エラーの内容を示します
         type: string
@@ -1605,11 +1611,6 @@ definitions:
         description: 相手側からのConnectに応答するのに必要なIDです
         type: string
         example: "da-102127d9-30de-413b-93f7-41a33e39d82b"
-
-  RemainingSec:
-    description: expiresinイベントのときのみ含まれます。クレデンシャルが失効するまでの時間(秒)です
-    type: integer
-    example: 300
 
   #GET /peers/ID/status
   PeerStatusMessage:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1316,7 +1316,7 @@ definitions:
         format: int64
         example: 1582789414
       ttl:
-        description: Time to live(ttl)。タイムスタンプ + ttl の時間でクレデンシャルが失効します。600から90000までの秒数を指定できます
+        description: TTL(600~90000の秒数で指定)。timestamp + TTL の時刻にcredentialが失効します。
         type: integer
         example: 3600
       authToken:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -144,7 +144,7 @@ paths:
       tags:
         - 1.peers
       summary: Peer認証のクレデンシャルを更新します
-      description: シグナリングサーバ接続し、Peer認証のクレデンシャルを更新します
+      description: シグナリングサーバに接続し、Peer認証のクレデンシャルを更新します。Peer認証機能が有効でなければ、クレデンシャルを更新する要求は無視されます。このとき、エラーイベントは発火しません
       operationId: peer_credential_update
       consumes:
         - application/json

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   description: 'SkyWay WebRTC Gatewayを操作するためのREST API仕様書'
-  version: 0.2.1
+  version: 1.0.0
   title: SkyWay WebRTC Gateway REST API
   termsOfService: 'http://nttcom.github.io/skyway/'
   contact:
@@ -39,7 +39,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: SkyWayサーバへアクセスするための情報を指定します
+          description: SkyWayサーバへアクセスするための情報を指定します。Peerの認証機能が有効の場合のみクレデンシャルが必要です
           required: true
           schema:
             $ref: '#/definitions/PeerOptions'
@@ -138,6 +138,73 @@ paths:
           description: Not Acceptable
         '408':
           description: Request Timeout
+
+  /peers/{peer_id}/credential:
+    put:
+      tags:
+        - 1.peers
+      summary: Peer認証のクレデンシャルを更新します
+      description: Peer認証のクレデンシャルを更新するためのリクエストをシグナリングサーバに送信します
+      operationId: peer_credential_update
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: peer_id
+          type: string
+          in: path
+          description: 他のピアがこのピアへ接続するときに使われるIDです。Peerオブジェクトの特定にも利用します
+          required: true
+        - name: token
+          type: string
+          in: query
+          description: Peerオブジェクトを利用するために必要なトークンです。他のユーザのリソースに対する誤操作防止のために指定します
+          required: true
+        - in: body
+          name: credential
+          description: Peerを認証するためのクレデンシャルです。認証機能が有効の場合のみ使えます
+          required: true
+          schema:
+            $ref: '#/definitions/PeerCredential'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            properties:
+              command_type:
+                type: string
+                example: "PEERS_CREDENTIAL_UPDATE"
+              params:
+                $ref: '#/definitions/PeerCredential'
+
+        '400':
+          description: Invalid input
+          schema:
+            required: [ "command_type", "params" ]
+            properties:
+              command_type:
+                type: string
+                example: "PEERS_CREDENTIAL_UPDATE"
+              params:
+                type: object
+                required: [ "errors" ]
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                          example: credential
+                        message:
+                          type: string
+                          example: "timestamp is non-integer value"
+        '403':
+          description: Forbidden(tokenが間違っている場合)
+        '404':
+          description: Not Found(peer_idが間違っている場合)
 
   /peers/{peer_id}/events:
     get:
@@ -1236,6 +1303,27 @@ definitions:
         type: boolean
         example: true
         description: SkyWayのTURNサーバを利用する場合はtrueにします。デフォルトはtrueです
+      credential:
+        $ref: '#/definitions/PeerCredential'
+
+  PeerCredential:
+    type: object
+    required: [ "timestamp", "ttl", "authToken"]
+    properties:
+      timestamp:
+        description: 現在のUNIXタイムスタンプです
+        type: integer
+        format: int64
+        example: 1582789414
+      ttl:
+        description: Time to live(ttl)。タイムスタンプ + ttl の時間でクレデンシャルが失効します。600から90000までの秒数を指定できます
+        type: integer
+        example: 3600
+      authToken:
+        description: HMACを利用して生成する認証用トークンです
+        type: string
+        format: byte
+        example: "jfdcSAe2kaj/i7/IO5MEvJA7JecVimAOb48WgLhJux4="
 
   PeerResponse:
     type: object
@@ -1459,6 +1547,7 @@ definitions:
           - "CONNECTION"
           - "CALL"
           - "CLOSE"
+          - "EXPIRESIN"
           - "ERROR"
         example: "TYPE_OF_EVENT"
       params:
@@ -1467,6 +1556,8 @@ definitions:
         $ref: '#/definitions/CallParametsers'
       data_params:
         $ref: '#/definitions/DataParametsers'
+      remainingSec:
+        $ref: '#/definitions/RemainingSec'
       error_message:
         description: エラーの内容を示します
         type: string
@@ -1515,6 +1606,10 @@ definitions:
         type: string
         example: "da-102127d9-30de-413b-93f7-41a33e39d82b"
 
+  RemainingSec:
+    description: expiresinイベントのときのみ含まれます。クレデンシャルが失効するまでの時間(秒)です
+    type: integer
+    example: 300
 
   #GET /peers/ID/status
   PeerStatusMessage:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -144,7 +144,7 @@ paths:
       tags:
         - 1.peers
       summary: Peer認証のクレデンシャルを更新します
-      description: Peer認証のクレデンシャルを更新するためのリクエストをシグナリングサーバに送信します。このAPIは認証機能が有効の場合のみ使えます
+      description: シグナリングサーバ接続し、Peer認証のクレデンシャルを更新します
       operationId: peer_credential_update
       consumes:
         - application/json
@@ -1321,6 +1321,8 @@ definitions:
       ttl:
         description: クレデンシャルの生存期間です。timestampからttl秒経過したとき、クレデンシャルが失効します。
         type: integer
+        minimum: 300
+        maximum: 90000
         example: 3600
       authToken:
         description: HMACを利用して生成する認証用トークンです

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1319,7 +1319,7 @@ definitions:
         format: int64
         example: 1582789414
       ttl:
-        description: TTL(600~90000の秒数で指定)。timestamp + TTL の時刻にcredentialが失効します。
+        description: クレデンシャルの生存期間です。timestampからttl秒経過したとき、クレデンシャルが失効します。
         type: integer
         example: 3600
       authToken:


### PR DESCRIPTION
This PR should be merged after releasing webrtc-gateway version 0.3.0

changes
- add `/peers/{peerId}/credential` api
- add `EXPIRESIN` event
- add `credential` to PeerOptions