### PR TITLE
Updated binary version from v0.3.2 to v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /skyway
 # glibc packages for Alpine Linux are prepared by Sasha Gerrand and the releases are published in sgerrand/alpine-pkg-glibc github repo.
 # https://github.com/sgerrand/alpine-pkg-glibc
 RUN apk add --no-cache --virtual tmpPackages ca-certificates wget && \
-    wget https://github.com/skyway/skyway-webrtc-gateway/releases/download/0.3.2/gateway_linux_x64 && \
+    wget https://github.com/skyway/skyway-webrtc-gateway/releases/download/0.4.0/gateway_linux_x64 && \
     chmod +x ./gateway_linux_x64 && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk && \


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary
Updated binary version from **`v0.3.2`** to **`v0.4.0`**.

Docker build success log.
```sh
(1/1) Installing libgcc (8.3.0-r0)
OK: 11 MiB in 19 packages
(1/1) Installing libuuid (2.33.2-r0)
OK: 11 MiB in 20 packages
(1/3) Purging tmpPackages (20211124.044206)
(2/3) Purging ca-certificates (20191127-r2)
Executing ca-certificates-20191127-r2.post-deinstall
(3/3) Purging wget (1.20.3-r0)
Executing busybox-1.30.1-r5.trigger
OK: 10 MiB in 17 packages
Removing intermediate container fb038073e307
 ---> 1e82ff280b8d
Step 6/7 : ENV LD_LIBRARY_PATH /lib64:/lib:/usr/lib
 ---> Running in cde785a63697
Removing intermediate container cde785a63697
 ---> ba2e3ee705b5
Step 7/7 : CMD ["/skyway/gateway_linux_x64"]
 ---> Running in 87cc81b3a424
Removing intermediate container 87cc81b3a424
 ---> 40f2c905bcec
Successfully built 40f2c905bcec
Successfully tagged gateway-image:latest
```

### Related Links (Issue, PR etc...) (_Optional_)
https://github.com/skyway/skyway-webrtc-gateway/releases/tag/0.4.0

### Check point

- [x] Check merge target branch
- [ ] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
