### PR TITLE
Fix GStreamer script

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -25,3 +25,6 @@ payload typeの指定が間違っているとredirectされません。これは
 
 x264encを利用した場合、H.264のChrome側で無視されるようです。OpenH264でエンコードすることにより表示されることを確認しています。
 https://github.com/skyway/skyway-webrtc-gateway/issues/14
+
+OpenH264でエンコードした映像をGStreamerで送信するサンプルコードを用意しています。
+https://github.com/skyway/skyway-webrtc-gateway/blob/master/gst-sample-script/video_openh264_send.sh

--- a/gst-sample-script/video_openh264_send.sh
+++ b/gst-sample-script/video_openh264_send.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gst-launch-1.0 v4l2src device=/dev/video1 ! videoconvert ! video/x-raw,width=640,height=480,framerate=60/1 ! videoconvert ! openh264enc enable-denoise=true qp-max=20 complexity=high background-detection=true rate-control=off ! rtph264pay ! udpsink port=50001 host=127.0.0.1 sync=false
+gst-launch-1.0 v4l2src device=/dev/video1 ! videoconvert ! video/x-raw,width=640,height=480,framerate=60/1 ! videoconvert ! openh264enc enable-denoise=true qp-max=20 complexity=high background-detection=true rate-control=off ! rtph264pay pt=100 ! udpsink port=50001 host=127.0.0.1 sync=false


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other (please describe):

### Summary

Chrome needed to use the same payload type as when MediaConnection was created.
So I fixed the sample script to use the payload type specified in util.rb. 

### Related Links (Issue, PR etc...) (_Optional_)

https://github.com/skyway/skyway-webrtc-gateway/issues/14

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
